### PR TITLE
fxied --dev and composer vcs prompt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,1 @@
 * text=auto eol=lf
-
-/tests         export-ignore
-.editorconfig  export-ignore
-.gitattributes export-ignore
-.gitignore     export-ignore
-.travis.yml    export-ignore
-phpunit.xml    export-ignore
-phpcs.xml      export-ignore

--- a/.gitattributes.skeleton
+++ b/.gitattributes.skeleton
@@ -1,0 +1,9 @@
+* text=auto eol=lf
+
+/tests         export-ignore
+.editorconfig  export-ignore
+.gitattributes export-ignore
+.gitignore     export-ignore
+.travis.yml    export-ignore
+phpunit.xml    export-ignore
+phpcs.xml      export-ignore

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 This is a skeleton to create packages implementing [PSR-15](https://github.com/http-interop/http-middleware) using composer:
 
 ```sh
-composer create-project --stability=dev middlewares/skeleton my-middleware
+composer create-project middlewares/skeleton my-middleware
 ```
-
-Note: After creating the project, Composer will ask to remove the existing VCS history (the .git directory). You should type `y` (it's the default option, anyway).
 
 ---
 

--- a/install.php
+++ b/install.php
@@ -32,6 +32,10 @@ foreach ([
     }
 }
 
+//Supersede .gitattributes
+unlink('.gitattributes');
+rename('.gitattributes.skeleton', '.gitattributes');
+
 //Remove the post-create-project-cmd composer script
 $composer = json_decode(file_get_contents(__DIR__.'/composer.json'), true);
 unset($composer['scripts']['post-create-project-cmd']);


### PR DESCRIPTION
@oscarotero Thank you for this project, it helped me to create my own [Skeleton project](https://github.com/cormy/server-middleware-skeleton) – I am not too satisfied with it, but if you find something which you think is appropriate for your package, then feel free to <kbd>CTRL</kbd>+<kbd>c</kbd> <kbd>CTRL</kbd>+<kbd>v</kbd>.

To give something back, I have created this PR. After merging and **tagging at least one release** (e.g.  `0.1.0`) there is no need for `--stability=dev` anymore. Moreover, composer won't display a prompt because of the `.git` directory anymore.