### PR TITLE
Added readme key pair to compose.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "http"
     ],
     "homepage": "https://github.com/middlewares/skeleton",
+    "readme": "README.md",
     "support": {
         "issues": "https://github.com/middlewares/skeleton/issues"
     },


### PR DESCRIPTION
Was looking at this and noticed that the readme key wasn't there.