### PR TITLE
Fixed misspelling of word "Runing" in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Good pull requests – patches, improvements, new features – are a fantastic h
 * Document any change in `README.md` and `CHANGELOG.md`
 * One pull request per feature. If you want to do more than one thing, send multiple pull request
 
-### Runing tests
+### Running tests
 
 ```sh
 composer test


### PR DESCRIPTION
Fixed "Runing" to the correct spelling "Running". Not sure how I missed this when I submitted the find for "comand", but wanted to do a pull request before I forget.